### PR TITLE
feat(function/exports): AddSharedInventory(society)

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -15,4 +15,9 @@ server_scripts {
 	'server/main.lua'
 }
 
+server_exports {
+    'GetSharedInventory',
+    'AddSharedInventory'
+}
+
 dependency 'es_extended'

--- a/server/main.lua
+++ b/server/main.lua
@@ -93,6 +93,7 @@ function GetSharedInventory(name)
 end
 
 function AddSharedInventory(society)
+    if type(society) ~= 'table' or not society?.name or not society?.label then return end
     -- society (array) containing name (string) and label (string)
 
     -- addon inventory:

--- a/server/main.lua
+++ b/server/main.lua
@@ -92,6 +92,19 @@ function GetSharedInventory(name)
 	return SharedInventories[name]
 end
 
+function AddSharedInventory(society)
+    -- society (array) containing name (string) and label (string)
+
+    -- addon inventory:
+    MySQL.Async.execute('INSERT INTO addon_inventory (name, label, shared) VALUES (@name, @label, @shared)', {
+        ['name'] = society.name,
+        ['label'] = society.label,
+        ['shared'] = 1
+    })
+
+    SharedInventories[society.name] = CreateAddonInventory(society.name, nil, {})
+end
+
 AddEventHandler('esx_addoninventory:getInventory', function(name, owner, cb)
 	cb(GetInventory(name, owner))
 end)


### PR DESCRIPTION
Gives the ability to create shared addon inventories during runtime. Also exports added for easy integration into ESX add-ons in the future.